### PR TITLE
Videos added to end

### DIFF
--- a/util/channel.go
+++ b/util/channel.go
@@ -382,7 +382,7 @@ func CreateChannelPage(channel *Channel, projectRoot string) error {
 
 // AddVideo adds a video to the channel page and saves it
 func (cp *ChannelPage) AddVideo(id, projectRoot string) error {
-	cp.Videos = append([]string{id}, cp.Videos...)
+	cp.Videos = append(cp.Videos, id)
 	err := cp.save(projectRoot)
 	if err != nil {
 		return err


### PR DESCRIPTION
Since adding the form on the site, people have been submitting videos in the order they'd like them shown.

This reverts an earlier change I made that was relevant when I was mass backfilling content